### PR TITLE
Issue-11 Create index.html

### DIFF
--- a/src/htdocs/index.html
+++ b/src/htdocs/index.html
@@ -15,7 +15,7 @@
       </header>
 
       <div class="page-content">
-        
+
         <p>
           The Hydra Web Service consists of 2 web service endpoints. Each end
           point has a slightly different API and different available data. For
@@ -23,8 +23,8 @@
         </p>
 
         <ul class="endpoints">
-          <li><a href="/ws/hydra/event.html">Event Service</a></li>
-          <li><a href="/ws/hydra/magnitude.html">Magnitude Service</a></li>
+          <li><a href="./event.html">Event Service</a></li>
+          <li><a href="./magnitude.html">Magnitude Service</a></li>
         </ul>
 
       </div>

--- a/src/htdocs/index.html
+++ b/src/htdocs/index.html
@@ -2,15 +2,31 @@
 <html>
 <head>
   <title>Hydra Web Service Documentation</title>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <link rel="stylesheet" href="css/index.css"/>
+  <script id="_fed_an_ua_tag" async="async" src="/lib/Universal-Federated-Analytics-Min.1.0.js?agency=DOI&amp;subagency=USGS&amp;pua=UA-7320779-1"></script>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons|Merriweather:400,400italic,700|Source+Sans+Pro:400,300,700"/>
 </head>
 <body>
-  <h1>Hydra Web Service Documentation</h1>
+  <main role="main" class="page" aria-labelledby="page-header">
+      <header class="page-header" id="page-header">
+        <h1>Hydra Web Service</h1>
+      </header>
 
-  <div id="application">
-    <p>TODO...</p>
-  </div>
+      <div class="page-content">
+        
+        <p>
+          The Hydra Web Service consists of 2 web service endpoints. Each end
+          point has a slightly different API and different available data. For
+          more details about each endpoint, please click a link below.
+        </p>
 
-  <script src="js/index.js"></script>
+        <ul class="endpoints">
+          <li><a href="/ws/hydra/event.html">Event Service</a></li>
+          <li><a href="/ws/hydra/magnitude.html">Magnitude Service</a></li>
+        </ul>
+
+      </div>
 </body>
 </html>


### PR DESCRIPTION
First version of index.html, fixes #11 

* Includes general description
* Includes a link to the (future) event endpoint documentation page
* Includes a link to the (future) magnitude endpoint documentation page
* Removed `<script src="js/index.js"></script>`, I don't know what it was supposed to do.

Used Geoserve documentation main page as example.